### PR TITLE
docs: document API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,20 @@ Use uvicorn to run this app.
 ```sh
 uvicorn main:app --host 0.0.0.0 --port 8000
 ```
+
+### Curl example
+
+With the server running, you can transcribe an audio file using `curl`:
+
+```sh
+curl -X 'POST' \
+  'http://localhost:8000/transcribe' \
+  -H 'accept: application/json' \
+  -H 'Content-Type: multipart/form-data' \
+  -F 'file=@voice-test.mp3;type=audio/mpeg'
+```
+
+### API Docs
+
+Interactive API documentation is available at http://localhost:8000/docs.
+You can also access the raw OpenAPI spec at http://localhost:8000/openapi.json.


### PR DESCRIPTION
## Summary
- add curl usage example for transcription endpoint
- document interactive API docs and OpenAPI spec URLs
- fix curl example to specify audio MIME type and headers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b185ec687c832d9b69e86b192016da