### PR TITLE
Document allowed origins configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ Setup env file using `.env.sample`
 cp -p .env.sample .env
 ```
 
+### Allowed Origins
+
+By default, no origins are allowed for Cross-Origin Resource Sharing (CORS).
+In production, specify the domains that should be permitted by setting the
+`ALLOW_ORIGINS` environment variable. For example:
+
+```sh
+echo 'ALLOW_ORIGINS=["https://your.vercel.app"]' >> .env
+```
+
+Restart the application after updating the setting.
+
 ## Run
 
 Use uvicorn to run this app.

--- a/app/config.py
+++ b/app/config.py
@@ -4,7 +4,7 @@ from typing import List
 
 class Settings(BaseSettings):
     WHISPER_MODEL: str = "small.en"
-    ALLOW_ORIGINS: List[AnyHttpUrl | str] = ["*"]  # Set to ["https://your.vercel.app"] for production
+    ALLOW_ORIGINS: List[AnyHttpUrl | str] = []  # e.g., ["https://your.vercel.app"] in production
 
     class Config:
         env_file = ".env"


### PR DESCRIPTION
## Summary
- Default to empty `ALLOW_ORIGINS` list
- Document how to configure CORS origins for production

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b195ea17e0832d96cc1859630e67b1