### PR TITLE
Enforce upload size limit in transcription API

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Use uvicorn to run this app.
 uvicorn main:app --host 0.0.0.0 --port 8000
 ```
 
+Uploaded audio files are limited to **10&nbsp;MB**. Larger files will be
+rejected with an HTTP `413 Payload Too Large` response.
+
 ### Curl example
 
 With the server running, you can transcribe an audio file using `curl`:

--- a/app/api/transcribe.py
+++ b/app/api/transcribe.py
@@ -8,9 +8,14 @@ from app.deps import get_whisper_model
 log = logging.getLogger(__name__)
 router = APIRouter()
 
+# Maximum allowed upload size in bytes (10 MB)
+MAX_UPLOAD_SIZE = 10 * 1024 * 1024
+
+
 class TranscribeResponse(BaseModel):
     text: str
     duration_ms: int
+
 
 @router.post("/transcribe", response_model=TranscribeResponse)
 async def transcribe(
@@ -19,6 +24,17 @@ async def transcribe(
 ):
     if file.content_type not in ("audio/wav", "audio/x-wav", "audio/mpeg", "audio/mp4"):
         raise HTTPException(415, detail="Unsupported file type")
+
+    # Determine the file size. Some UploadFile implementations expose a `size`
+    # attribute; otherwise, fall back to measuring the underlying file object.
+    size = getattr(file, "size", None)
+    if size is None:
+        file.file.seek(0, os.SEEK_END)
+        size = file.file.tell()
+        file.file.seek(0)
+
+    if size > MAX_UPLOAD_SIZE:
+        raise HTTPException(413, detail="File too large")
 
     with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as tmp:
         shutil.copyfileobj(file.file, tmp)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -66,3 +66,19 @@ def test_transcribe_unsupported_type():
         asyncio.run(transcribe_api.transcribe(file=upload, model=DummyModel()))
 
     assert exc.value.status_code == 415
+
+
+def test_transcribe_file_too_large():
+    big_bytes = BytesIO(b"0" * (transcribe_api.MAX_UPLOAD_SIZE + 1))
+    upload = UploadFile(
+        filename="big.mp3",
+        file=big_bytes,
+        headers={"content-type": "audio/mpeg"},
+    )
+
+    import pytest
+
+    with pytest.raises(transcribe_api.HTTPException) as exc:
+        asyncio.run(transcribe_api.transcribe(file=upload, model=DummyModel()))
+
+    assert exc.value.status_code == 413


### PR DESCRIPTION
## Summary
- reject audio uploads larger than 10MB with HTTP 413
- document 10MB upload limit in README
- add test coverage for file-size validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b195ec9410832d8e0c33b1161deadf