### PR TITLE
refactor tests

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,9 +1,11 @@
 import os
 import sys
 import types
+import json
 import asyncio
 from io import BytesIO
 
+import pytest
 from fastapi import UploadFile
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -16,7 +18,7 @@ class DummyModel:
         return {"text": "test transcription"}
 
 
-def _load_model(name: str) -> DummyModel:
+def _load_model(name: str) -> "DummyModel":
     return DummyModel()
 
 
@@ -27,58 +29,59 @@ from app.api import transcribe as transcribe_api  # noqa: E402
 from main import health as root_health  # noqa: E402
 
 
+@pytest.fixture
+def dummy_model() -> DummyModel:
+    return DummyModel()
+
+
+@pytest.fixture
+def upload_factory():
+    def _factory(data: bytes, filename: str, content_type: str) -> UploadFile:
+        return UploadFile(
+            filename=filename,
+            file=BytesIO(data),
+            headers={"content-type": content_type},
+        )
+
+    return _factory
+
+
 def test_health_route():
     assert root_health() == {"status": "ok"}
 
 
-def test_transcribe_success():
+def test_transcribe_success(upload_factory, dummy_model):
     with open("voice-test.mp3", "rb") as f:
-        upload = UploadFile(
-            filename="voice-test.mp3",
-            file=BytesIO(f.read()),
-            headers={"content-type": "audio/mpeg"},
-        )
+        upload = upload_factory(f.read(), "voice-test.mp3", "audio/mpeg")
 
     result = asyncio.run(
-        transcribe_api.transcribe(file=upload, model=DummyModel())
+        transcribe_api.transcribe(file=upload, model=dummy_model)
     )
 
     assert result.status_code == 200
-    data = result.body
-    # body is bytes; parse JSON
-    import json
-
-    data = json.loads(data)
+    data = json.loads(result.body)
     assert data["text"] == "test transcription"
     assert isinstance(data["duration_ms"], int)
 
 
-def test_transcribe_unsupported_type():
-    upload = UploadFile(
-        filename="test.txt",
-        file=BytesIO(b"data"),
-        headers={"content-type": "text/plain"},
-    )
-
-    import pytest
-
-    with pytest.raises(transcribe_api.HTTPException) as exc:
-        asyncio.run(transcribe_api.transcribe(file=upload, model=DummyModel()))
-
-    assert exc.value.status_code == 415
-
-
-def test_transcribe_file_too_large():
-    big_bytes = BytesIO(b"0" * (transcribe_api.MAX_UPLOAD_SIZE + 1))
-    upload = UploadFile(
-        filename="big.mp3",
-        file=big_bytes,
-        headers={"content-type": "audio/mpeg"},
-    )
-
-    import pytest
+@pytest.mark.parametrize(
+    "data,filename,content_type,expected_status",
+    [
+        (b"data", "test.txt", "text/plain", 415),
+        (
+            b"0" * (transcribe_api.MAX_UPLOAD_SIZE + 1),
+            "big.mp3",
+            "audio/mpeg",
+            413,
+        ),
+    ],
+)
+def test_transcribe_invalid_uploads(
+    data, filename, content_type, expected_status, upload_factory, dummy_model
+):
+    upload = upload_factory(data, filename, content_type)
 
     with pytest.raises(transcribe_api.HTTPException) as exc:
-        asyncio.run(transcribe_api.transcribe(file=upload, model=DummyModel()))
+        asyncio.run(transcribe_api.transcribe(file=upload, model=dummy_model))
 
-    assert exc.value.status_code == 413
+    assert exc.value.status_code == expected_status


### PR DESCRIPTION
## Summary
- refactor tests with reusable fixtures
- consolidate invalid upload cases via parametrization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b199d63538832db5ab55d1b1ea7669