### PR TITLE
Rename transcribe endpoint to transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ With the server running, you can transcribe an audio file using `curl`:
 
 ```sh
 curl -X 'POST' \
-  'http://localhost:8000/transcribe' \
+  'http://localhost:8000/transcription' \
   -H 'accept: application/json' \
   -H 'Content-Type: multipart/form-data' \
   -F 'file=@voice-test.mp3;type=audio/mpeg'

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
-from app.api.transcribe import router as transcribe_router
+from app.api.transcription import router as transcription_router
 from app.api.health import router as health_router
 
 router = APIRouter()
-router.include_router(transcribe_router)
+router.include_router(transcription_router)
 router.include_router(health_router)

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
-from app.api.transcribe import router as transcribe_router
+from app.api.transcription import router as transcription_router
 from app.api.health import router as health_router
 
 router = APIRouter()
-router.include_router(transcribe_router)
+router.include_router(transcription_router)
 router.include_router(health_router)

--- a/app/api/transcription.py
+++ b/app/api/transcription.py
@@ -12,12 +12,12 @@ router = APIRouter()
 MAX_UPLOAD_SIZE = 10 * 1024 * 1024
 
 
-class TranscribeResponse(BaseModel):
+class TranscriptionResponse(BaseModel):
     text: str
     duration_ms: int
 
 
-@router.post("/transcribe", response_model=TranscribeResponse)
+@router.post("/transcription", response_model=TranscriptionResponse)
 async def transcribe(
     file: UploadFile = File(...),
     model = Depends(get_whisper_model),

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.config import settings
-from app.api.transcribe import router as api_router
+from app.api.transcription import router as api_router
 
 app = FastAPI(title="Voice Transcription API")
 


### PR DESCRIPTION
## Summary
- rename API route to `/transcription`
- update imports, tests and docs accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4331d4dd4832dae096d58225bf2e5